### PR TITLE
uberAgent 7.0 release adjustments

### DIFF
--- a/vl.Core/Domain/Attributes/TransformDataType.cs
+++ b/vl.Core/Domain/Attributes/TransformDataType.cs
@@ -1,0 +1,7 @@
+﻿namespace vl.Core.Domain.Attributes;
+
+public enum TransformDataType
+{
+   String,
+   Int
+}

--- a/vl.Core/Domain/Attributes/TransformFieldAttribute.cs
+++ b/vl.Core/Domain/Attributes/TransformFieldAttribute.cs
@@ -5,12 +5,18 @@ namespace vl.Core.Domain.Attributes
    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
    public class TransformFieldAttribute : TransformFieldBaseAttribute
    {
-      public string TargetField { get; }
-
-
+      protected string TargetField { get; }
+      protected TransformDataType DataType { get; } = TransformDataType.String;
+      
       public TransformFieldAttribute(string sourceField, string targetField) : base(sourceField)
       {
          TargetField = targetField;
+      }
+
+      public TransformFieldAttribute(string sourceField, string targetField, TransformDataType transformDataType) : base(sourceField)
+      {
+         TargetField = targetField;
+         DataType = transformDataType;
       }
 
       public TransformFieldAttribute(string sourceField, string targetField, TransformMethod transformMethod) : base(sourceField, transformMethod)
@@ -18,10 +24,8 @@ namespace vl.Core.Domain.Attributes
          TargetField = targetField;
       }
 
+      public override TransformDataType GetDataType() => DataType;
 
-      public override string GetTargetField(string value)
-      {
-         return TargetField;
-      }
+      public override string GetTargetField(string value) => TargetField;
    }
 }

--- a/vl.Core/Domain/Attributes/TransformFieldBaseAttribute.cs
+++ b/vl.Core/Domain/Attributes/TransformFieldBaseAttribute.cs
@@ -24,7 +24,9 @@ namespace vl.Core.Domain.Attributes
       public static string TransformTrailingBackslashes(string itemValue)
       {
          var quotes = itemValue.Count(c => c == '"');
-         if (quotes >= 2 || !itemValue.TrimEnd().EndsWith('"'))
+
+         itemValue = itemValue.Replace(@"\", @"\\");
+         if (quotes >= 2)
             itemValue = itemValue.Trim().Replace("\"", "\\\"");
 
          return itemValue;

--- a/vl.Core/Domain/Attributes/TransformFieldBaseAttribute.cs
+++ b/vl.Core/Domain/Attributes/TransformFieldBaseAttribute.cs
@@ -39,6 +39,7 @@ namespace vl.Core.Domain.Attributes
          };
       }
 
+      public abstract TransformDataType GetDataType();
       public abstract string GetTargetField(string value);
    }
 }

--- a/vl.Core/Domain/Attributes/TransformFieldPathAttribute.cs
+++ b/vl.Core/Domain/Attributes/TransformFieldPathAttribute.cs
@@ -2,6 +2,10 @@
 {
    public class TransformFieldPathAttribute : TransformFieldBaseAttribute
    {
+      public string TargetField { get; }
+      public string TargetFieldPath { get; }
+
+
       public TransformFieldPathAttribute(string sourceField, string targetField, string targetFieldPath) :
          base(sourceField)
       {
@@ -16,10 +20,10 @@
          TargetFieldPath = targetFieldPath;
       }
 
-      public string TargetField { get; }
-
-      public string TargetFieldPath { get; }
-
+      public override TransformDataType GetDataType()
+      {
+         return TransformDataType.String;
+      }
 
       public override string GetTargetField(string value)
       {

--- a/vl.Sysmon.Converter/Domain/ConvertEntity.cs
+++ b/vl.Sysmon.Converter/Domain/ConvertEntity.cs
@@ -58,29 +58,25 @@ namespace vl.Sysmon.Converter.Domain
                var lastValueInGroup = i + 1 == value.Count;
                var groupRelation = lastValueInGroup ? string.Empty : $" {item.GroupRelation} ";
                var query = string.Empty;
-               var stringType = "r";
-               item.Value = item.Value.Replace("%%", "%");
+               item.Value = item.Value.Replace("%%", "%").Replace("\\", "\\\\").Replace("\"", "\\\"");
 
                if (item.Value.EndsWith(@"\") && !item.Value.EndsWith(@"\\"))
-               {
                   item.Value = item.Value.Replace(@"\", @"\\");
-                  stringType = string.Empty;
-               }
 
                switch (item.Condition)
                {
                   case "is":
-                     query = $"{item.Field} == {stringType}\"{item.Value}\"{groupRelation}";
+                     query = $"{item.Field} == {item.GetValueFormated()}{groupRelation}";
                      break;
                   case "begin with":
-                     query = $"istartswith({item.Field}, {stringType}\"{item.Value}\"){groupRelation}";
+                     query = $"istartswith({item.Field}, {item.GetValueFormated()}){groupRelation}";
                      break;
                   case "end with":
-                     query = $"iendswith({item.Field}, {stringType}\"{item.Value}\"){groupRelation}";
+                     query = $"iendswith({item.Field}, {item.GetValueFormated()}){groupRelation}";
                      break;
                   case "image":
                   case "contains":
-                     query = $"icontains({item.Field}, {stringType}\"{item.Value}\"){groupRelation}";
+                     query = $"icontains({item.Field}, {item.GetValueFormated()}){groupRelation}";
                      break;
                   case "contains all":
                   case "contains any":
@@ -97,7 +93,7 @@ namespace vl.Sysmon.Converter.Domain
                         }
                         else
                         {
-                           query = query + $"icontains({item.Field}, {stringType}\"{s}\"){relation}";
+                           query = query + $"icontains({item.Field}, \"{s}\"){relation}";
                         }
                      }
 
@@ -108,7 +104,7 @@ namespace vl.Sysmon.Converter.Domain
 
                      break;
                   case "is not":
-                     query = $"{item.Field} != {stringType}\"{item.Value}\"{groupRelation}";
+                     query = $"{item.Field} != {item.GetValueFormated()}{groupRelation}";
                      break;
                   default:
                      Log.Error("Condition: {condition} is not implemented.", item.Condition);

--- a/vl.Sysmon.Converter/Domain/ConvertEntity.cs
+++ b/vl.Sysmon.Converter/Domain/ConvertEntity.cs
@@ -58,7 +58,7 @@ namespace vl.Sysmon.Converter.Domain
                var lastValueInGroup = i + 1 == value.Count;
                var groupRelation = lastValueInGroup ? string.Empty : $" {item.GroupRelation} ";
                var query = string.Empty;
-               item.Value = item.Value.Replace("%%", "%").Replace("\\", "\\\\").Replace("\"", "\\\"");
+               item.Value = item.Value.Replace("%%", "%");
 
                if (item.Value.EndsWith(@"\") && !item.Value.EndsWith(@"\\"))
                   item.Value = item.Value.Replace(@"\", @"\\");

--- a/vl.Sysmon.Converter/Domain/ConvertEntity.cs
+++ b/vl.Sysmon.Converter/Domain/ConvertEntity.cs
@@ -199,6 +199,7 @@ namespace vl.Sysmon.Converter.Domain
                GroupRelation = groupRelationProperty,
                Field = baseProperties.Field,
                Value = baseProperties.Value,
+               DataType = baseProperties.DataType,
                Condition = baseProperties.Condition,
                OnMatch = onMatchProperty,
                RuleId = 0
@@ -264,23 +265,23 @@ namespace vl.Sysmon.Converter.Domain
       [TransformFieldPath("ParentImage", "Parent.Name", "Parent.Path", TransformMethod.RemoveTrailingBackslashes)]
       [TransformFieldPath("Image", "Process.Name", "Process.Path", TransformMethod.RemoveTrailingBackslashes)]
       [TransformField("User", "Process.User")]
-      [TransformField("ParentProcessId", "Parent.Id")]
-      [TransformField("ProcessId", "Process.Id")]
+      [TransformField("ParentProcessId", "Parent.Id", TransformDataType.Int)]
+      [TransformField("ProcessId", "Process.Id", TransformDataType.Int)]
       [TransformField("ParentCommandLine", "Parent.CommandLine", TransformMethod.RemoveTrailingBackslashes)]
       [TransformField("CommandLine", "Process.CommandLine", TransformMethod.RemoveTrailingBackslashes)]
-      [TransformField("DestinationPort", "Net.Target.Port")]
+      [TransformField("DestinationPort", "Net.Target.Port", TransformDataType.Int)]
       [TransformField("DestinationHostname", "Net.Target.Name")]
       [TransformField("DestinationIp", "Net.Target.Ip")]
       [TransformField("TargetObject", "Reg.Key.Target")]
       [TransformFieldPath("ImageLoaded", "Image.Name", "Image.Path", TransformMethod.RemoveTrailingBackslashes)]
       [TransformField("ImageLoadHashes", "Image.Hashes")]
       [TransformField("Hashes", "Process.Hashes")]
-      [TransformField("TerminalSessionId", "Process.SessionId")]
+      [TransformField("TerminalSessionId", "Process.SessionId", TransformDataType.Int)]
       [TransformField("Protocol", "Net.Target.Protocol")]
       [TransformField("Signed", "Image.IsSigned")]
       [TransformField("Signature", "Image.Signature")]
       [TransformField("SignatureStatus", "Image.SignatureStatus")]
-      [TransformField("NewThreadId", "Thread.Id")]
+      [TransformField("NewThreadId", "Thread.Id", TransformDataType.Int)]
       [TransformField("StartAddress", "Thread.StartAddress")]
       [TransformField("StartModule", "Thread.StartModule")]
       [TransformField("StartFunction", "Thread.StartFunction")]
@@ -345,7 +346,8 @@ namespace vl.Sysmon.Converter.Domain
                {
                   Field = attribute.GetTargetField(itemValue),
                   Condition = itemCondition,
-                  Value = attribute.TransformValue(itemValue)
+                  Value = attribute.TransformValue(itemValue),
+                  DataType = attribute.GetDataType()
                };
             }
          }

--- a/vl.Sysmon.Converter/Domain/SysmonConditionBase.cs
+++ b/vl.Sysmon.Converter/Domain/SysmonConditionBase.cs
@@ -1,9 +1,26 @@
-﻿namespace vl.Sysmon.Converter.Domain
+﻿using System;
+using vl.Core.Domain.Attributes;
+
+namespace vl.Sysmon.Converter.Domain
 {
    public class SysmonConditionBase
    {
       public string Field { get; set; }
       public string Value { get; set; }
       public string Condition { get; set; }
+      public TransformDataType DataType { get; set; }
+
+      public string GetValueFormated()
+      {
+         switch(DataType)
+         {
+            case TransformDataType.String:
+               return $"\"{Value}\"";
+            case TransformDataType.Int:
+               return Value;
+            default:
+               throw new ArgumentOutOfRangeException();
+         }
+      }
    }
 }

--- a/vl.Sysmon.Converter/vl.Sysmon.Converter.csproj
+++ b/vl.Sysmon.Converter/vl.Sysmon.Converter.csproj
@@ -7,6 +7,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishTrimmed>true</PublishTrimmed>
     <Version>1.0.1</Version>
+    <StartupObject>vl.Sysmon.Converter.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Conversion is now data type safe, so ints are not converted to strings.
- Using normal instead of raw strings, so escaping backslashes now.